### PR TITLE
rescue file not found exception for blob.download

### DIFF
--- a/lib/ratonvirus/storage/active_storage.rb
+++ b/lib/ratonvirus/storage/active_storage.rb
@@ -82,6 +82,8 @@ module Ratonvirus
           tempfile.rewind
 
           yield tempfile.path
+        rescue StandardError
+            return
         ensure
           tempfile.close!
         end


### PR DESCRIPTION
blob.download would raise an exception if physical file is not available or deleted. This would cause this to break and eventually Virus checking via Ratonvirus won't succeed and Effected file won't be deleted and virus would stay in the system. 

for has_many_attached  if any single file is deleted from the system and new virus is uploaded. Previously it was crashing and virus removal was not being performed. This patch would fix it